### PR TITLE
Guard WindowSize apply against an empty display-mode list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixed a crash when applying the window-size option while the app is backgrounded: on Android the display-mode list is empty whenever the native window is detached, and the callback indexed entry `-1` of the empty list (`SIGSEGV` at `fault_addr=0xffffffffffffec` on the main thread, seen on AYN Thor in issue #27). The callback now skips the update until display modes are available again.
+- Log-file version banner now matches the released APK version; 0.3.0 builds still reported `1.5.0-roadmap-v34` in `log.txt`, which made log triage misleading.
+
+## 0.3.0 (2026-07-11)
+
 ### Unified Android launcher
 
 - Replaced the direct SDL home-screen entry with a lightweight launcher that validates the game installation before startup and provides driver/render-mode, touch-control, FPS, intro-skip, Vulkan validation and GFXReconstruct settings.

--- a/UnleashedRecomp/os/android/logger_android.cpp
+++ b/UnleashedRecomp/os/android/logger_android.cpp
@@ -486,8 +486,8 @@ void os::logger::Init()
     // Create log.txt promptly (and roll the previous one) so a tester always finds a
     // fresh file, even if this run happens to log nothing else before a freeze.
     WriteLogRecord("[logger]", nullptr, "Unleashed Recomp log started", 28);
-    static constexpr char BuildVersion[] = "=== APK VERSION: 1.5.0-roadmap-v34 (2026-07-11) ===";
-    static constexpr char BuildId[] = "ANDROID_BUILD_ID=1.5.0-roadmap-v34-driver-zip-crashlog";
+    static constexpr char BuildVersion[] = "=== APK VERSION: 1.5.1-roadmap-v36 (2026-07-12) ===";
+    static constexpr char BuildId[] = "ANDROID_BUILD_ID=1.5.1-roadmap-v36-window-size-guard";
     WriteLogRecord("[build]", nullptr, BuildVersion, sizeof(BuildVersion) - 1);
     WriteLogRecord("[build]", nullptr, BuildId, sizeof(BuildId) - 1);
     LogDeviceInfo();

--- a/UnleashedRecomp/user/config.cpp
+++ b/UnleashedRecomp/user/config.cpp
@@ -785,6 +785,12 @@ void Config::CreateCallbacks()
     {
         auto displayModes = GameWindow::GetDisplayModes();
 
+        // On Android the list is empty while the native window is detached
+        // (backgrounded app); size() - 1 would underflow to -1 and read at
+        // vector data nullptr - sizeof(SDL_DisplayMode).
+        if (displayModes.empty())
+            return;
+
         // Use largest supported resolution if overflowed.
         if (def->Value >= displayModes.size())
             def->Value = displayModes.size() - 1;

--- a/android-apk/app/build.gradle
+++ b/android-apk/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.sega.sonicunr"
         minSdkVersion 29
         targetSdkVersion 34
-        versionCode 10
-        versionName "1.5.0-roadmap-v35"
+        versionCode 11
+        versionName "1.5.1-roadmap-v36"
         externalNativeBuild {
             ndkBuild {
                 arguments "APP_PLATFORM=android-29"


### PR DESCRIPTION
On Android SDL reports no display modes while the native window is detached (backgrounded app). The WindowSize apply callback then computed size() - 1 == -1 and read SDL_DisplayMode entry -1 of an empty vector, crashing the main thread at fault_addr 0xffffffffffffec (seen on AYN Thor running 0.3.0, issue #27). Skip the update until display modes are available again.

Also bump the log-file version banner, which still reported 1.5.0-roadmap-v34 in 0.3.0 builds, and advance the APK to 1.5.1-roadmap-v36 / version code 11.