### PR TITLE
Android: keep .config under Android/media for fresh installs

### DIFF
--- a/UnleashedRecomp/os/android/storage_android.cpp
+++ b/UnleashedRecomp/os/android/storage_android.cpp
@@ -155,4 +155,33 @@ namespace os::android
 
         return root;
     }
+
+    const std::filesystem::path & GetConfigRoot()
+    {
+        static std::filesystem::path root = []() -> std::filesystem::path
+        {
+            std::error_code ec;
+
+            // Existing install: ".config" is already populated next to the game files
+            // (legacy internal layout, external app storage, or a media install that
+            // predates this function). Keep using it so upgrading never relocates saves.
+            if (std::filesystem::exists(GetDataRoot() / ".config" / USER_DIRECTORY, ec))
+                return GetDataRoot();
+
+            // Fresh install: prefer Android/media so ".config" (and the save data inside
+            // it) sits at a real filesystem path other apps can read without root or SAF.
+            const std::filesystem::path &media = GetExternalMediaDir();
+            if (!media.empty())
+            {
+                std::filesystem::path mediaRoot = media / "UnleashedRecomp";
+                std::filesystem::create_directories(mediaRoot, ec);
+                if (ProbeDirWritable(mediaRoot))
+                    return mediaRoot;
+            }
+
+            return GetDataRoot();
+        }();
+
+        return root;
+    }
 }

--- a/UnleashedRecomp/os/android/storage_android.h
+++ b/UnleashedRecomp/os/android/storage_android.h
@@ -24,4 +24,11 @@ namespace os::android
     // storage, then a populated one under Android/media; defaults to external app
     // storage, which users can populate from a PC without root.
     const std::filesystem::path & GetDataRoot();
+
+    // Root directory for ".config" (settings, saves). An existing install keeps using
+    // ".config" next to GetDataRoot() so upgrading never relocates a user's save data.
+    // A fresh install prefers Android/media instead: unlike Android/data, it is not
+    // hidden from other apps by scoped storage on Android 11+, so tools that need a
+    // real filesystem path (e.g. Syncthing) can reach saves there without root or SAF.
+    const std::filesystem::path & GetConfigRoot();
 }

--- a/UnleashedRecomp/user/paths.cpp
+++ b/UnleashedRecomp/user/paths.cpp
@@ -23,9 +23,10 @@ std::filesystem::path BuildUserPath()
     CoTaskMemFree(knownPath);
 #elif defined(__ANDROID__)
     // No meaningful $HOME/passwd entry for an app UID; getpwuid()->pw_dir returns a
-    // generic path apps can't write to. Keep config/saves next to the game files
-    // (legacy internal install or external app storage, whichever GetDataRoot picked).
-    userPath = os::android::GetDataRoot() / ".config" / USER_DIRECTORY;
+    // generic path apps can't write to. See GetConfigRoot() for where config/saves
+    // actually land (next to the game files for an existing install, Android/media
+    // for a fresh one so raw-path tools like Syncthing can reach saves).
+    userPath = os::android::GetConfigRoot() / ".config" / USER_DIRECTORY;
 #elif defined(__linux__) || defined(__APPLE__)
     const char* homeDir = getenv("HOME");
 #if defined(__linux__)

--- a/android-apk/app/src/main/java/org/libsdl/app/AppStorage.java
+++ b/android-apk/app/src/main/java/org/libsdl/app/AppStorage.java
@@ -42,13 +42,37 @@ final class AppStorage {
         return external != null ? external : internal;
     }
 
-    static File configFile(Context context) {
-        return new File(activeGameRoot(context), ".config/UnleashedRecomp/config.toml");
+    /**
+     * Mirrors the native GetConfigRoot(): an existing install keeps ".config" next to
+     * the game files it already has, so upgrading never relocates saves. A fresh
+     * install prefers Android/media, since unlike Android/data it isn't hidden from
+     * other apps by scoped storage on Android 11+ - so a raw-path tool such as
+     * Syncthing can be pointed at the save folder directly, without SAF or root.
+     */
+    static File configRoot(Context context) {
+        File dataRoot = activeGameRoot(context);
+        if (new File(dataRoot, ".config/UnleashedRecomp").isDirectory()) {
+            return dataRoot;
+        }
+
+        File media = mediaBase(context);
+        if (media != null) {
+            File mediaRoot = new File(media, "UnleashedRecomp");
+            if (mediaRoot.isDirectory() || mediaRoot.mkdirs()) {
+                return mediaRoot;
+            }
+        }
+
+        return dataRoot;
     }
 
-    /** Where native paths.cpp keeps save data: <game root>/.config/UnleashedRecomp/save. */
+    static File configFile(Context context) {
+        return new File(configRoot(context), ".config/UnleashedRecomp/config.toml");
+    }
+
+    /** Where native paths.cpp keeps save data: <config root>/.config/UnleashedRecomp/save. */
     static File saveDir(Context context) {
-        return new File(activeGameRoot(context), ".config/UnleashedRecomp/save");
+        return new File(configRoot(context), ".config/UnleashedRecomp/save");
     }
 
     static File transferRoot(Context context) {

--- a/android-apk/app/src/main/java/org/libsdl/app/ModManagerActivity.java
+++ b/android-apk/app/src/main/java/org/libsdl/app/ModManagerActivity.java
@@ -177,7 +177,7 @@ public final class ModManagerActivity extends Activity {
             }
         }
 
-        File userDirectory = new File(activeGameRoot, ".config/UnleashedRecomp");
+        File userDirectory = new File(AppStorage.configRoot(this), ".config/UnleashedRecomp");
         File managerDatabase = new File(userDirectory, MOD_DATABASE_NAME);
         File sourceDatabase = findSourceDatabase(userDirectory, managerDatabase);
         Map<String, Map<String, String>> sourceIni = readIni(sourceDatabase);
@@ -465,8 +465,7 @@ public final class ModManagerActivity extends Activity {
     }
 
     private void saveSelection() {
-        File activeGameRoot = getActiveGameRoot();
-        File userDirectory = new File(activeGameRoot, ".config/UnleashedRecomp");
+        File userDirectory = new File(AppStorage.configRoot(this), ".config/UnleashedRecomp");
         if (!userDirectory.isDirectory() && !userDirectory.mkdirs()) {
             showError(getString(R.string.mod_manager_error_directory, userDirectory));
             return;


### PR DESCRIPTION
Android/data is hidden from other apps by scoped storage on Android 11+, both via raw filesystem access and via SAF, so the save folder exposed through `UnleashedDocumentsProvider` can't be reached by tools that need a real path - e.g. Syncthing fails with "folder path missing" when pointed at a SAF tree from a custom app-owned `DocumentsProvider`.

`Android/media` isn't subject to that restriction (per the existing comments on `GetDataRoot()`/`GetExternalMediaDir()`), so this routes a fresh install's `.config` (settings + save data) there via a new `GetConfigRoot()`, mirrored in `AppStorage.configRoot()` on the Java side. An existing install keeps using `.config` next to its current game files, so upgrading never relocates anyone's save data.

`ModManagerActivity` now resolves its mod database/`cpkredir.ini` through `AppStorage.configRoot()` too, so it stays in sync with where native code actually reads `.config` from.

**Untested** - I don't have an NDK/CMake toolchain set up to compile this, and no device to verify Syncthing can actually reach `Android/media/<pkg>/UnleashedRecomp` with the permissions it requests. Opening this as a proposal for review/testing rather than a ready-to-merge change.
