### PR TITLE
Android: extend rendering under the display cutout

### DIFF
--- a/android-apk/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-apk/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -409,6 +409,15 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         } catch(Exception ignored) {
         }
 
+        // Landscape gameplay would otherwise leave a black bar over the display cutout:
+        // the platform default keeps window content out of the cutout in landscape,
+        // and only extends under it in portrait. Opt in explicitly on both edges.
+        if (Build.VERSION.SDK_INT >= 28 /* Android 9 (P) */) {
+            WindowManager.LayoutParams params = getWindow().getAttributes();
+            params.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+            getWindow().setAttributes(params);
+        }
+
         setContentView(mLayout);
 
         setWindowStyle(false);

--- a/android-apk/app/src/main/res/values/styles.xml
+++ b/android-apk/app/src/main/res/values/styles.xml
@@ -2,7 +2,9 @@
 <resources>
     <!-- Base application theme. -->
     <style name="AppTheme" parent="android:Theme.NoTitleBar.Fullscreen">
-        <!-- Customize your theme here. -->
+        <!-- Without this, the platform default avoids the display cutout in landscape
+             (only portrait extends under it by default), leaving a black bar over it. -->
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
     <style name="ModManagerTheme" parent="android:style/Theme.Material.Light.NoActionBar">
         <item name="android:fontFamily">sans</item>


### PR DESCRIPTION
Neither the theme nor SDLActivity opted into
windowLayoutInDisplayCutoutMode, so the platform default applied: a window is allowed under the cutout in portrait, but avoids it in landscape, leaving a black bar over the cutout area. Since the game only runs in landscape, this always showed as dead space at the cutout's short edge.

Set LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES both at the theme level (AppTheme, so it applies from window creation) and programmatically in SDLActivity.onCreate() as a fallback for the same effect at runtime.

Untested: no NDK/CMake/Gradle toolchain available in this environment, and no cutout device to confirm rendering actually extends into that area rather than just no longer being clipped.
<img width="1280" height="582" alt="photo_2026-09-05_05-18-04" src="https://github.com/user-attachments/assets/2d7bd68f-26e3-46ef-a1c2-f57f57e1f801" />
